### PR TITLE
Adds dedicated exceptions #6919

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,22 @@
-# pickup-points-api-client
+![Olza Logistic Logo](docs/olza-logo-small.png)
 
 Olza Logistic's Pickup Point API Client PHP library.
 
+---
+
 ## Changelog
+
+* dev (????-??-??)
+  * Fixed API response code not being included in the thrown exception.
+  * Added dedicated exceptions to reflect API error codes (when `throwOnError` is enabled).
+  * Added dedicated `ApiCode` class to match API codes.
+  * Added `Exceptions` chapter to documentation.
+  * Renamed `ResponseIncorrectParserException` to `InvalidResponseStructureException`.
+
 
 * v1.2.1 (2023-10-05)
   * Updated library documentation
+
 
 * v1.2.0 (2023-06-03)
   * All files are now declaring strict types.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Olza Logistic's Pickup Point API Client PHP library.
 
 ---
 
-## Changelog
+# Changelog
 
 * dev (????-??-??)
   * Fixed API response code not being included in the thrown exception.

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,6 @@
         "test": "vendor/bin/phpunit -c phpunit.xml -c phpunit.xml.dist",
         "phpstan": "vendor/bin/phpstan analyze -c phpstan.neon.dist",
         "lint": "@composer phpstan",
-        "mdlint": "markdownlint -c .markdownlint.yaml.dist docs README.md --ignore LICENSE.md"
+        "mdlint": "markdownlint -c .markdownlint.yaml.dist docs *.md --ignore LICENSE.md"
     }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,3 +18,4 @@
   * [`Params` class - passing method arguments](params.md#passing-method-arguments)
   * [`Result` class - accessing response data](response.md#accessing-response-data)
     * [`Data` class - accessing response payload](response.md#accessing-response-payload)
+  * [Exceptions](exceptions.md)

--- a/docs/client.md
+++ b/docs/client.md
@@ -18,6 +18,7 @@
   * [`Params` class - passing method arguments](params.md#passing-method-arguments)
   * [`Result` class - accessing response data](response.md#accessing-response-data)
     * [`Data` class - accessing response payload](response.md#accessing-response-payload)
+  * [Exceptions](exceptions.md)
 
 ---
 

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -22,25 +22,18 @@
 
 ---
 
-## Requirements
+## Exceptions
 
-The PP API Client library has the following requirements:
+The library throws exceptions of the following classes (all exceptions are in the
+`\OlzaLogistic\PpApi\Client\Exception` namespace):
 
-* PHP 7.4 or newer.
-* One HTTP client library to handle HTTP requests and responses.
-* PSR-17 HTTP Factory library to create request/response objects, stream objects, and URI objects.
+* `InvalidResponseStructureException` is thrown when the
+  response from the API is malformed (i.e. missing required fields, or having invalid values).
 
-![Note](note.png) Though various HTTP clients are supported, only one is required to make the library functional. The
-choice of HTTP client can be based on the specific needs of your project. Aside from the solid
-implementations provided, any future HTTP client adhering to the PSR standards will also be
-supported out of the box.
+When [`Client` object](client.md) is instantiated with `throwOnError()` option set, the following
+exceptions will be thrown on API errors:
 
-### HTTP Clients
-
-The library directly supports and was tested with the following HTTP clients:
-
-* Guzzle (version 7.4 or newer)
-*Symfony HttpClient (version 5.4 or newer)
-
-It also supports
-[PSR compatible HTTP clients](https://packagist.org/providers/psr/http-client-implementation)
+* `AccessDeniedException` - thrown when the API rejects the request due to invalid credentials (like
+  invalid or outdated access token).
+* `ObjectNotFoundException` - thrown when requested data was not found (i.e. invalid PP reference
+  ID, or invalid carrier ID etc.).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,6 +18,7 @@
   * [`Params` class - passing method arguments](params.md#passing-method-arguments)
   * [`Result` class - accessing response data](response.md#accessing-response-data)
     * [`Data` class - accessing response payload](response.md#accessing-response-payload)
+  * [Exceptions](exceptions.md)
 
 ---
 

--- a/docs/params.md
+++ b/docs/params.md
@@ -18,6 +18,7 @@
   * [`Params` class - passing method arguments](params.md#passing-method-arguments)
   * [`Result` class - accessing response data](response.md#accessing-response-data)
     * [`Data` class - accessing response payload](response.md#accessing-response-payload)
+  * [Exceptions](exceptions.md)
 
 ---
 

--- a/docs/response.md
+++ b/docs/response.md
@@ -18,6 +18,7 @@
   * [`Params` class - passing method arguments](params.md#passing-method-arguments)
   * [`Result` class - accessing response data](response.md#accessing-response-data)
     * [`Data` class - accessing response payload](response.md#accessing-response-payload)
+  * [Exceptions](exceptions.md)
 
 ---
 
@@ -51,6 +52,12 @@ public function getCode(): int
 ```
 
 Gets API returned status code associated with the response (this is not a HTTP status code).
+The expected values are:
+
+* `ApiCode::ERROR_OBJECT_NOT_FOUND` (`100`): API rejects the request due to invalid credentials (
+  like invalid or outdated access token)
+* `ApiCode::ERROR_ACCESS_DENIED` (`101`): API rejects the request due to invalid credentials (like
+  invalid or outdated access token).
 
 ```php
 public function getMessage(): ?string

--- a/src/ApiCode.php
+++ b/src/ApiCode.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+/*
+ * Olza Logistic's Pickup Points API client
+ *
+ * @author    Marcin Orlowski <marcin.orlowski (#) develart (.) cz>
+ * @copyright 2023 DevelArt
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      https://github.com/develart-projects/pickup-points-api-client/
+ */
+
+namespace OlzaLogistic\PpApi\Client;
+
+/**
+ * PP Api response codes.
+ *
+ * Based on src/Consts/ApiCode.php
+ */
+class ApiCode
+{
+    /**
+     * API rejects the request due to invalid credentials (like invalid or outdated access token)
+     *
+     * @var int
+     */
+    public const ERROR_OBJECT_NOT_FOUND = 100;
+
+    /**
+     * Requested data was not found (i.e. invalid PP reference ID, or invalid carrier ID etc.).
+     *
+     * @var int
+     */
+    public const ERROR_ACCESS_DENIED = 101;
+
+}

--- a/src/Exception/AccessDeniedException.php
+++ b/src/Exception/AccessDeniedException.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+/*
+ * Olza Logistic's Pickup Points API client
+ *
+ * @author    Marcin Orlowski <marcin.orlowski (#) develart (.) cz>
+ * @copyright 2023 DevelArt
+ * @license   Proprietary
+ */
+
+namespace OlzaLogistic\PpApi\Client\Exception;
+
+use OlzaLogistic\PpApi\Client\ApiCode;
+
+/**
+ * Thrown when API call fails due to access denied (like invalid API token)
+ */
+class AccessDeniedException extends MethodFailedException
+{
+    public function __construct(?string    $reason = null,
+                                int        $code = ApiCode::ERROR_ACCESS_DENIED,
+                                \Throwable $previous = null)
+    {
+        $reason ??= 'Access denied';
+        parent::__construct($reason, $code, $previous);
+    }
+
+} // end of class

--- a/src/Exception/InvalidResponseStructureException.php
+++ b/src/Exception/InvalidResponseStructureException.php
@@ -11,11 +11,11 @@ declare(strict_types=1);
 
 namespace OlzaLogistic\PpApi\Client\Exception;
 
-class ResponseIncorrectParserException extends \RuntimeException
+class InvalidResponseStructureException extends \RuntimeException
 {
     public function __construct(?string $msg = null, int $code = 0, \Throwable $previous = null)
     {
-        $msg ??= "Unexpected data structure. Most likely wrong parser is used.";
+        $msg ??= "Invalid response data structure.";
         parent::__construct($msg, $code, $previous);
     }
 

--- a/src/Exception/ObjectNotFoundException.php
+++ b/src/Exception/ObjectNotFoundException.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+/*
+ * Olza Logistic's Pickup Points API client
+ *
+ * @author    Marcin Orlowski <marcin.orlowski (#) develart (.) cz>
+ * @copyright 2022-2023 DevelArt
+ * @license   Proprietary
+ */
+
+namespace OlzaLogistic\PpApi\Client\Exception;
+
+use OlzaLogistic\PpApi\Client\ApiCode;
+
+/**
+ * Thrown when API call fails due to requested object not found.
+ */
+class ObjectNotFoundException extends MethodFailedException
+{
+    public function __construct(?string    $reason = null,
+                                int        $code = ApiCode::ERROR_OBJECT_NOT_FOUND,
+                                \Throwable $previous = null)
+    {
+        $reason ??= 'Object not found';
+        parent::__construct($reason, $code, $previous);
+    }
+
+} // end of class

--- a/src/Result.php
+++ b/src/Result.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace OlzaLogistic\PpApi\Client;
 
-use OlzaLogistic\PpApi\Client\Exception\ResponseIncorrectParserException;
+use OlzaLogistic\PpApi\Client\Exception\InvalidResponseStructureException;
 use OlzaLogistic\PpApi\Client\Model\PickupPoint;
 use OlzaLogistic\PpApi\Client\Model\Spedition;
 use Psr\Http\Message\ResponseInterface;
@@ -66,7 +66,7 @@ class Result
         /** @var array $json */
         $json = \json_decode($jsonStr, true, 32, \JSON_THROW_ON_ERROR);
         if (!static::isApiResponseArrayValid($json, $extraKeys)) {
-            throw new ResponseIncorrectParserException();
+            throw new InvalidResponseStructureException();
         }
 
         /** @var string $message */
@@ -118,10 +118,8 @@ class Result
             $result->setData($data);
 
         } catch (\Throwable $ex) {
-            $result = (static::asError())
-                ->setMessage($ex->getMessage());
+            $result = static::fromThrowable($ex);
         }
-        /** @var static $result */
         return $result;
     }
 
@@ -158,8 +156,7 @@ class Result
             $result->setData($data);
 
         } catch (\Throwable $ex) {
-            $result = (static::asError())
-                ->setMessage($ex->getMessage());
+            $result = static::fromThrowable($ex);
         }
         return $result;
     }


### PR DESCRIPTION
  * Fixed API response code not being included in the thrown exception.
  * Added dedicated exceptions to reflect API error codes (when `throwOnError` is enabled).
  * Added dedicated `ApiCode` class to match API codes.
  * Added `Exceptions` chapter to documentation.
  * Renamed `ResponseIncorrectParserException` to `InvalidResponseStructureException`.
